### PR TITLE
fix _restoreTMN error, items(["logs_tmn"]) => items["logs_tmn"]

### DIFF
--- a/trackmenot.js
+++ b/trackmenot.js
@@ -1230,7 +1230,7 @@ TRACKMENOT.TMNSearch = function () {
 
 
             try {
-                tmnLogs = items(["logs_tmn"]);
+                tmnLogs = items["logs_tmn"];
             } catch (ex) {
                 tmnLogs = [];
                 add_log({


### PR DESCRIPTION
error treated items as function, error appeared in trackmenot logs in options page:

google |   |   | [ERROR in trackmenot.js] Error in invocation of storage.get(optional [string\|array\|object] keys, function callback): No matching signature. | 08:12:15 11/11/2022
-- | -- | -- | -- | --
google |   |   | [ERROR in trackmenot.js] Error in invocation of storage.get(optional [string\|array\|object] keys, function callback): No matching signature. | 08:12:14 11/11/2022

